### PR TITLE
Pin the inkwell version to latest stable on master

### DIFF
--- a/llvm-plugin/Cargo.toml
+++ b/llvm-plugin/Cargo.toml
@@ -54,7 +54,7 @@ target-all = ["inkwell/target-all"]
 
 [dependencies]
 inkwell = { git = "https://github.com/TheDan64/inkwell", rev = "5c9f7fc" }
-inkwell_internals = { git = "https://github.com/TheDan64/inkwell", rev = "5c9f7fc"" }
+inkwell_internals = { git = "https://github.com/TheDan64/inkwell", rev = "5c9f7fc" }
 llvm-plugin-macros = { path = "../llvm-plugin-macros", version = "0.2", optional = true }
 
 [build-dependencies]

--- a/llvm-plugin/Cargo.toml
+++ b/llvm-plugin/Cargo.toml
@@ -53,8 +53,8 @@ target-riscv = ["inkwell/target-riscv"]
 target-all = ["inkwell/target-all"]
 
 [dependencies]
-inkwell = { git = "https://github.com/TheDan64/inkwell", rev = "7684346" }
-inkwell_internals = { git = "https://github.com/TheDan64/inkwell", rev = "7684346" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", rev = "5c9f7fc" }
+inkwell_internals = { git = "https://github.com/TheDan64/inkwell", rev = "5c9f7fc"" }
 llvm-plugin-macros = { path = "../llvm-plugin-macros", version = "0.2", optional = true }
 
 [build-dependencies]

--- a/llvm-plugin/Cargo.toml
+++ b/llvm-plugin/Cargo.toml
@@ -53,8 +53,8 @@ target-riscv = ["inkwell/target-riscv"]
 target-all = ["inkwell/target-all"]
 
 [dependencies]
-inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master" }
-inkwell_internals = { git = "https://github.com/TheDan64/inkwell", branch = "master" }
+inkwell = { git = "https://github.com/TheDan64/inkwell", rev = "7684346" }
+inkwell_internals = { git = "https://github.com/TheDan64/inkwell", rev = "7684346" }
 llvm-plugin-macros = { path = "../llvm-plugin-macros", version = "0.2", optional = true }
 
 [build-dependencies]

--- a/llvm-plugin/src/analysis.rs
+++ b/llvm-plugin/src/analysis.rs
@@ -71,13 +71,17 @@ impl FunctionAnalysisManager {
             "Analysis cannot request its own result"
         );
 
-        unsafe {
-            let res = crate::get_function_analysis_cached_result(
-                self.inner,
-                id,
-                function.as_value_ref().cast(),
-            );
-            (!res.is_null()).then_some(Box::leak(Box::from_raw(res.cast())))
+        let res = crate::get_function_analysis_cached_result(
+             self.inner,
+             id,
+             function.as_value_ref().cast(),
+        );
+
+        if !res.is_null() {
+            let res = unsafe { Box::leak(Box::from_raw(res.cast())) };
+            Some(res)
+        } else {
+            None
         }
     }
 
@@ -214,7 +218,12 @@ impl ModuleAnalysisManager {
             module.as_mut_ptr().cast(),
         );
 
-        unsafe { (!res.is_null()).then_some(Box::leak(Box::from_raw(res.cast()))) }
+        if !res.is_null() {
+            let res = unsafe { Box::leak(Box::from_raw(res.cast())) };
+            Some(res)
+        } else {
+            None
+        }
     }
 
     /// Returns a [FunctionAnalysisManagerProxy], which is essentially an interface

--- a/llvm-plugin/src/analysis.rs
+++ b/llvm-plugin/src/analysis.rs
@@ -72,9 +72,9 @@ impl FunctionAnalysisManager {
         );
 
         let res = crate::get_function_analysis_cached_result(
-             self.inner,
-             id,
-             function.as_value_ref().cast(),
+            self.inner,
+            id,
+            function.as_value_ref().cast(),
         );
 
         if !res.is_null() {

--- a/llvm-plugin/src/ffi.rs
+++ b/llvm-plugin/src/ffi.rs
@@ -6,7 +6,7 @@ pub type AnalysisKey = *const u8;
 
 #[link(name = "llvm-plugin-cpp")]
 extern "C" {
-    #[llvm_versions(15.0..=latest)]
+    #[llvm_versions(15..)]
     pub(crate) fn passBuilderAddFullLinkTimeOptimizationLastEPCallback(
         builder: *mut c_void,
         cb: *const c_void,
@@ -14,7 +14,7 @@ extern "C" {
         cb_sys: extern "C" fn(*const c_void, *mut c_void, crate::OptimizationLevel),
     );
 
-    #[llvm_versions(15.0..=latest)]
+    #[llvm_versions(15..)]
     pub(crate) fn passBuilderAddFullLinkTimeOptimizationEarlyEPCallback(
         builder: *mut c_void,
         cb: *const c_void,
@@ -22,7 +22,7 @@ extern "C" {
         cb_sys: extern "C" fn(*const c_void, *mut c_void, crate::OptimizationLevel),
     );
 
-    #[llvm_versions(15.0..=latest)]
+    #[llvm_versions(15..)]
     pub(crate) fn passBuilderAddOptimizerEarlyEPCallback(
         builder: *mut c_void,
         cb: *const c_void,
@@ -30,7 +30,7 @@ extern "C" {
         cb_sys: extern "C" fn(*const c_void, *mut c_void, crate::OptimizationLevel),
     );
 
-    #[llvm_versions(11.0..=latest)]
+    #[llvm_versions(11..)]
     pub(crate) fn passBuilderAddOptimizerLastEPCallback(
         builder: *mut c_void,
         cb: *const c_void,
@@ -38,7 +38,7 @@ extern "C" {
         cb_sys: extern "C" fn(*const c_void, *mut c_void, crate::OptimizationLevel),
     );
 
-    #[llvm_versions(12.0..=latest)]
+    #[llvm_versions(12..)]
     pub(crate) fn passBuilderAddPipelineEarlySimplificationEPCallback(
         builder: *mut c_void,
         cb: *const c_void,
@@ -46,7 +46,7 @@ extern "C" {
         cb_sys: extern "C" fn(*const c_void, *mut c_void, crate::OptimizationLevel),
     );
 
-    #[llvm_versions(12.0..=latest)]
+    #[llvm_versions(12..)]
     pub(crate) fn passBuilderAddPipelineStartEPCallback(
         builder: *mut c_void,
         cb: *const c_void,
@@ -110,7 +110,7 @@ extern "C" {
         pass_sys: extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> crate::PreservedAnalyses,
     );
 
-    #[llvm_versions(12.0..=latest)]
+    #[llvm_versions(12..)]
     pub(crate) fn modulePassManagerIsEmpty(manager: *mut c_void) -> bool;
 
     pub(crate) fn functionPassManagerAddPass(
@@ -120,7 +120,7 @@ extern "C" {
         pass_sys: extern "C" fn(*mut c_void, *mut c_void, *mut c_void) -> crate::PreservedAnalyses,
     );
 
-    #[llvm_versions(12.0..=latest)]
+    #[llvm_versions(12..)]
     pub(crate) fn functionPassManagerIsEmpty(manager: *mut c_void) -> bool;
 
     pub(crate) fn moduleAnalysisManagerRegisterPass(

--- a/llvm-plugin/src/pass_builder.rs
+++ b/llvm-plugin/src/pass_builder.rs
@@ -318,7 +318,7 @@ impl PassBuilder {
     /// This extension point allows adding optimization once at the start
     /// of the pipeline. This does not apply to 'backend' compiles (LTO and
     /// ThinLTO link-time pipelines).
-    #[llvm_versions(12.0..=latest)]
+    #[llvm_versions(12..)]
     pub fn add_pipeline_start_ep_callback<T>(&mut self, cb: T)
     where
         T: Fn(&mut ModulePassManager, OptimizationLevel) + 'static,
@@ -361,7 +361,7 @@ impl PassBuilder {
     ///
     /// This extension point allows adding optimization right after passes
     /// that do basic simplification of the input IR.
-    #[llvm_versions(12.0..=latest)]
+    #[llvm_versions(12..)]
     pub fn add_pipeline_early_simplification_ep_callback<T>(&mut self, cb: T)
     where
         T: Fn(&mut ModulePassManager, OptimizationLevel) + 'static,
@@ -404,7 +404,7 @@ impl PassBuilder {
     ///
     /// This extension point allows adding passes that run after everything
     /// else.
-    #[llvm_versions(11.0..=latest)]
+    #[llvm_versions(11..)]
     pub fn add_optimizer_last_ep_callback<T>(&mut self, cb: T)
     where
         T: Fn(&mut ModulePassManager, OptimizationLevel) + 'static,
@@ -447,7 +447,7 @@ impl PassBuilder {
     ///
     /// This extension point allow adding passes that run at Link Time,
     /// before Full Link Time Optimization.
-    #[llvm_versions(15.0..=latest)]
+    #[llvm_versions(15..)]
     pub fn add_full_lto_early_ep_callback<T>(&mut self, cb: T)
     where
         T: Fn(&mut ModulePassManager, OptimizationLevel) + 'static,
@@ -490,7 +490,7 @@ impl PassBuilder {
     ///
     /// This extensions point allow adding passes that run at Link Time,
     /// after Full Link Time Optimization.
-    #[llvm_versions(15.0..=latest)]
+    #[llvm_versions(15..)]
     pub fn add_full_lto_last_ep_callback<T>(&mut self, cb: T)
     where
         T: Fn(&mut ModulePassManager, OptimizationLevel) + 'static,
@@ -533,7 +533,7 @@ impl PassBuilder {
     ///
     /// This extension point allows adding passes just before the main
     /// module-level optimization passes.
-    #[llvm_versions(15.0..=latest)]
+    #[llvm_versions(15..)]
     pub fn add_optimizer_early_ep_callback<T>(&mut self, cb: T)
     where
         T: Fn(&mut ModulePassManager, OptimizationLevel) + 'static,

--- a/llvm-plugin/src/pass_manager.rs
+++ b/llvm-plugin/src/pass_manager.rs
@@ -65,7 +65,7 @@ impl ModulePassManager {
     }
 
     /// Returns if the pass manager contains any passes.
-    #[llvm_versions(12.0..=latest)]
+    #[llvm_versions(12..)]
     pub fn is_empty(&self) -> bool {
         unsafe { super::modulePassManagerIsEmpty(self.inner) }
     }
@@ -128,7 +128,7 @@ impl FunctionPassManager {
     }
 
     /// Returns if the pass manager contains any passes.
-    #[llvm_versions(12.0..=latest)]
+    #[llvm_versions(12..)]
     pub fn is_empty(&self) -> bool {
         unsafe { super::functionPassManagerIsEmpty(self.inner) }
     }


### PR DESCRIPTION
The current master branch of inkwell seems to change a lot and for compatibility issues it might help to pin the commit.

I was having trouble building this as well because the macro for `llvm_versions` now uses different syntax so I fixed that as well.

Please let me know what steps I can take to help get this merged, I really like the idea of this tool and this allows me to use it for my research.